### PR TITLE
Fix bug css not processed

### DIFF
--- a/src/DappCard/dappCard.css
+++ b/src/DappCard/dappCard.css
@@ -15,7 +15,7 @@
 /* along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-@import '../_colors.css';
+@import '../_colors';
 
 .container {
   height: 100%;

--- a/src/DappLink/dappLink.css
+++ b/src/DappLink/dappLink.css
@@ -15,7 +15,7 @@
 /* along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-@import '../_colors.css';
+@import '../_colors';
 
 .link {
   color: $linkColor;

--- a/src/SelectionList/selectionList.css
+++ b/src/SelectionList/selectionList.css
@@ -15,7 +15,7 @@
 /* along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-@import '../_colors.css';
+@import '../_colors';
 
 .item {
   cursor: pointer;

--- a/src/Signer/Layout/Side/side.css
+++ b/src/Signer/Layout/Side/side.css
@@ -15,7 +15,7 @@
 /* along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-@import '../../_layout.css';
+@import '../../_layout';
 
 .signerSide {
   box-sizing: border-box;

--- a/src/Signer/RequestSign/requestSign.css
+++ b/src/Signer/RequestSign/requestSign.css
@@ -15,7 +15,7 @@
 /* along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-@import '../_layout.css';
+@import '../_layout';
 
 .container {
   display: flex;

--- a/src/Signer/TransactionDetails/transactionDetails.css
+++ b/src/Signer/TransactionDetails/transactionDetails.css
@@ -15,7 +15,7 @@
 /* along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-@import '../_layout.css';
+@import '../_layout';
 
 .account {
   text-align: center;


### PR DESCRIPTION
Small bug:

DappCard.css was doing a `@import('../colors.css')`, and when SASS processes it, it thinks it's a vanilla CSS import, so doesn't import the variables. This resulted in having some uncompiled CSS in the lib folder.

Followed the comment in this answer: https://stackoverflow.com/questions/24741486/import-with-sass-not-combining-files#answer-24741668