### PR TITLE
Import SUI as commonjs

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -26,7 +26,12 @@
         "moduleName": "babel-runtime"
       }
     ],
-    "transform-semantic-ui-react-imports",
+    [
+      "transform-semantic-ui-react-imports",
+      {
+        "importType": "commonjs"
+      }
+    ],
     "transform-decorators-legacy"
   ]
 }


### PR DESCRIPTION
`import { Button } from 'semantic-ui-react;'` outputs `import Button  from 'semantic-ui-react/dist/es/Button`, which is cool. But this file `semantic-ui-react/dist/es/Button` contains a `import ... from '...'`, i.e. is es2015. It works fine with CRA and webpack on the shell, but somehow with jest I got some annoying `Unexpected token: import`.

This PR lets the repo import commonjs SUI, so that we have no headaches.