### PR TITLE
Fix UI glitches, align styles

### DIFF
--- a/src/Form/Input/input.css
+++ b/src/Form/Input/input.css
@@ -25,7 +25,13 @@
 }
 
 .input {
+  opacity: 1 !important;
+  position: relative;
+
+  input[disabled],
   input[readonly] {
+    border-color: transparent !important;
     cursor: text;
+    opacity: 0.5;
   }
 }

--- a/src/Form/InputAddress/inputAddress.css
+++ b/src/Form/InputAddress/inputAddress.css
@@ -21,7 +21,7 @@
 
   [data-address-img] {
     position: absolute;
-    top: -7px;
+    bottom: 0;
     left: 8px;
   }
 }
@@ -52,11 +52,7 @@
 .icon,
 .iconDisabled {
   position: absolute;
-  top: 33px;
-
-  &.noLabel {
-    top: 10px;
-  }
+  bottom: 4px;
 
   &.noCopy {
     left: 5px;

--- a/src/Form/InputAddress/inputAddress.js
+++ b/src/Form/InputAddress/inputAddress.js
@@ -71,11 +71,8 @@ class InputAddress extends Component {
       ? 'null'
       : null;
 
-    // FIXME: The is not advisable, fixes the display issue, however the name should come from
-    // a common component.
-    //    account.name || (value ? 'UNNAMED' : value)
     const displayValue = text && account
-      ? (account.name || (value ? 'UNNAMED' : value))
+      ? (account.name || value)
       : (nullName || value);
 
     if (small) {


### PR DESCRIPTION
Aligns with https://github.com/paritytech/parity/issues/7221

1. Adjust input disabled/readonly to have similar styles (+ remove border)
2. Fix alignment of address icons (both for labelled and non-labelled cases)
3. Don't display unnamed for contracts (rather address)