### PR TITLE
Don't try to div undefined

### DIFF
--- a/src/MethodDecoding/methodDecoding.js
+++ b/src/MethodDecoding/methodDecoding.js
@@ -600,7 +600,7 @@ class MethodDecoding extends Component {
 
     return (
       <span className={styles.tokenValue}>
-        { value.div(token.format).toFormat(5) }<small> { token.tag }</small>
+        { value ? value.div(token.format).toFormat(5) : '0.00000' }<small> { token.tag }</small>
       </span>
     );
   }


### PR DESCRIPTION
The right solution is to understand 100% why there is an undefined passed in - this is (hopefully) just a band-aid to move into that direction.

Part of https://github.com/paritytech/parity/issues/7217