### PR TITLE
Remove AccountLink as a link

### DIFF
--- a/src/Signer/Account/AccountLink/accountLink.css
+++ b/src/Signer/Account/AccountLink/accountLink.css
@@ -14,7 +14,9 @@
 /* You should have received a copy of the GNU General Public License
 /* along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 */
+
 .container {
-  text-decoration: none;
   color: inherit;
+  padding: 0 2em;
+  text-decoration: none;
 }

--- a/src/Signer/Account/AccountLink/accountLink.js
+++ b/src/Signer/Account/AccountLink/accountLink.js
@@ -16,7 +16,6 @@
 
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { Link } from 'react-router';
 
 import styles from './accountLink.css';
 
@@ -61,12 +60,9 @@ export default class AccountLink extends Component {
     }
 
     return (
-      <Link
-        className={`${styles.container} ${className}`}
-        to={this.state.link}
-      >
+      <div className={`${styles.container} ${className}`}>
         { children || address }
-      </Link>
+      </div>
     );
   }
 


### PR DESCRIPTION
We don't have an external accounts app (hold-over from v1), break link to non-existent location.