### PR TITLE
Fix vouchers bug

### DIFF
--- a/src/DappVouchFor/store.js
+++ b/src/DappVouchFor/store.js
@@ -32,7 +32,7 @@ export default class Store {
   }
 
   async attachContract () {
-    const address = await Contracts.get().registry.lookupAddress('vouchfor');
+    const address = await Contracts.get(this._api).registry.lookupAddress('vouchfor');
 
     if (!address || /^0x0*$/.test(address)) {
       return null;


### PR DESCRIPTION
I got a `cannot get parity of undefined` in a line with `this.api.parity` when using the DappVouchFor in a dapp. This fixes it.