### PR TITLE
Add mobx as a peer dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4447,26 +4447,6 @@
         "minimist": "0.0.8"
       }
     },
-    "mobx": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/mobx/-/mobx-3.3.1.tgz",
-      "integrity": "sha1-w4/Booeg3aP11Lhe/hE3/t2dzfA="
-    },
-    "mobx-react": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/mobx-react/-/mobx-react-4.3.4.tgz",
-      "integrity": "sha1-WM2hBbgBj5v4e9beMzrF6w1cnf4=",
-      "requires": {
-        "hoist-non-react-statics": "2.3.1"
-      },
-      "dependencies": {
-        "hoist-non-react-statics": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.3.1.tgz",
-          "integrity": "sha1-ND24TGAYxlB3iJgkATWhQg7iLOA="
-        }
-      }
-    },
     "moment": {
       "version": "2.19.2",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.19.2.tgz",

--- a/package.json
+++ b/package.json
@@ -67,8 +67,6 @@
     "js-sha3": "0.6.1",
     "keycode": "^2.1.9",
     "lodash": "4.17.4",
-    "mobx": "3.3.1",
-    "mobx-react": "4.3.4",
     "moment": "2.19.2",
     "qrcode-generator": "1.3.1",
     "react-ace": "5.7.0",
@@ -92,6 +90,8 @@
     "zxcvbn": "4.4.2"
   },
   "peerDependencies": {
+    "mobx": "^3.4.1",
+    "mobx-react": "^4.3.5",
     "prop-types": "^15.6.0",
     "react": "^16.1.1"
   }


### PR DESCRIPTION
Add mobx as a **peer** dependency. The DappIcon bug not showing is caused by the fact that there were multiple instances of mobx in node_modules.